### PR TITLE
Add generator of variable access

### DIFF
--- a/app/src/main/kotlin/org/exeval/cfg/VarAccessGenerator.kt
+++ b/app/src/main/kotlin/org/exeval/cfg/VarAccessGenerator.kt
@@ -1,0 +1,33 @@
+package org.exeval.cfg
+
+import org.exeval.ast.AnyVariable
+import org.exeval.ast.BinaryOperation
+import org.exeval.cfg.interfaces.UsableMemoryCell
+
+private const val BASE_POINTER_NUMBER = 5
+
+// You can either specify function frame offset manually or leave it as null
+// In the latter case it will be taken from RBP register (PhysicalRegister with id BASE_POINTER_NUMBER)
+class VarAccessGenerator(val functionFrameOffset: Int? = null) {
+    fun generateVarAccess(cell: UsableMemoryCell): Tree {
+        return when (cell) {
+            is UsableMemoryCell.MemoryPlace -> {
+                val functionFrameOffsetTree = if (functionFrameOffset != null)
+                    Constant(functionFrameOffset)
+                else
+                    PhysicalRegister(BASE_POINTER_NUMBER)
+
+                Memory(
+                    BinaryOperation(
+                        functionFrameOffsetTree,
+                        Constant(cell.offset),
+                        BinaryOperationType.SUBTRACT
+                    )
+                )
+            }
+            is UsableMemoryCell.VirtReg -> {
+                VirtualRegister(cell.idx)
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/org/exeval/cfg/VarAccessGeneratorTest.kt
+++ b/app/src/test/kotlin/org/exeval/cfg/VarAccessGeneratorTest.kt
@@ -1,0 +1,56 @@
+package org.exeval.cfg
+
+import org.exeval.cfg.interfaces.UsableMemoryCell
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val RBP_INDEX = 5
+
+class VarAccessGeneratorTest {
+    @Test
+    fun `Generate accesses for RBP`() {
+        val generator = VarAccessGenerator()
+
+        val regCell = UsableMemoryCell.VirtReg(108)
+        val memCell = UsableMemoryCell.MemoryPlace(24)
+
+        val regExpected = VirtualRegister(108)
+        val memExpected = Memory(
+            BinaryOperation(
+                PhysicalRegister(RBP_INDEX),
+                Constant(24),
+                BinaryOperationType.SUBTRACT
+            )
+        )
+
+        val regActual = generator.generateVarAccess(regCell)
+        val memActual = generator.generateVarAccess(memCell)
+
+        assertEquals(regExpected, regActual)
+        assertEquals(memExpected, memActual)
+    }
+
+    @Test
+    fun `Generate accesses for offsets`() {
+        val offset = 1028
+        val generator = VarAccessGenerator(offset)
+
+        val regCell = UsableMemoryCell.VirtReg(108)
+        val memCell = UsableMemoryCell.MemoryPlace(24)
+
+        val regExpected = VirtualRegister(108)
+        val memExpected = Memory(
+            BinaryOperation(
+                Constant(offset),
+                Constant(24),
+                BinaryOperationType.SUBTRACT
+            )
+        )
+
+        val regActual = generator.generateVarAccess(regCell)
+        val memActual = generator.generateVarAccess(memCell)
+
+        assertEquals(regExpected, regActual)
+        assertEquals(memExpected, memActual)
+    }
+}


### PR DESCRIPTION
Closes #85. I've implemented it in another object for easier testing.

To implement function generate_var_access you only need to do something like this:
```kotlin
class FunctionFrameManager {

    // ...

    private val varAccessGenerator = VarAccessGenerator()

    // ...

    fun generate_var_access(x: AnyVariable): Tree {
        val cell = this.variable_to_virtual_register(x)
        return varAccessGenerator(cell)
    }
}
```