### PR TITLE
Add instruction patterns for other kinds

### DIFF
--- a/app/src/main/kotlin/org/exeval/cfg/Tree.kt
+++ b/app/src/main/kotlin/org/exeval/cfg/Tree.kt
@@ -27,7 +27,7 @@ enum class BinaryOperationType : OperationType{
 
 data class UnaryOp(val child: Tree, val operation: UnaryOperationType) : Tree
 enum class UnaryOperationType : OperationType{
-    NOT, MINUS, INCREMENT, DECREMENT, CALL
+    NOT, MINUS, INCREMENT, DECREMENT, CALL, IF
 }
 
 data object Call : Tree

--- a/app/src/main/kotlin/org/exeval/instructions/Instruction.kt
+++ b/app/src/main/kotlin/org/exeval/instructions/Instruction.kt
@@ -7,7 +7,7 @@ enum class OperationAsm {
     AND, OR, XOR, XCHG, NEG,
     INC, DEC, CALL, RET, CMP,
     JMP, JG, JGE, JE, ADC,
-    CMOVG, CMOVGE, CMOVE
+    CMOVG, CMOVGE, CMOVE, JNE
 }
 
 data class Instruction(

--- a/app/src/main/kotlin/org/exeval/instructions/InstructionCoverer.kt
+++ b/app/src/main/kotlin/org/exeval/instructions/InstructionCoverer.kt
@@ -28,15 +28,15 @@ class InstructionCoverer(private val instructionPatterns : Map<OperationType, Li
             when(tree){
                 is Call, Return ->{
                     // no tree
-                    return matchResult.createInstruction(listOf(), null)
+                    return matchResult.createInstruction(listOf(), listOf())
                 }
                 is Memory -> {
                     // label
-                    return matchResult.createInstruction(listOf(), tree)
+                    return matchResult.createInstruction(listOf(), listOf(tree))
                 }
                 is Register -> {
                     // register
-                    return matchResult.createInstruction(listOf(), tree)
+                    return matchResult.createInstruction(listOf(), listOf(tree))
                 }
                 else -> {
                     throw IllegalArgumentException("Cover tree got unexpected tree: " + tree.toString())
@@ -49,9 +49,9 @@ class InstructionCoverer(private val instructionPatterns : Map<OperationType, Li
         val registerChildren = matchResult.children.filterIsInstance(Register::class.java)
         val resultTree = when (tree) {
             is Assignable ->
-                tree
+                listOf(tree)
             else ->
-                null
+                listOf()
         }
         return result + matchResult.createInstruction(registerChildren, resultTree)
     }

--- a/app/src/main/kotlin/org/exeval/instructions/InstructionPattern.kt
+++ b/app/src/main/kotlin/org/exeval/instructions/InstructionPattern.kt
@@ -5,7 +5,7 @@ import org.exeval.cfg.*
 
 data class InstructionMatchResult (
     val children: List<Tree>,
-    val createInstruction: (operands : List<OperandArgumentType>, destRegister : Assignable?) -> List<Instruction>
+    val createInstruction: (operands : List<OperandArgumentType>, dest : List<OperandArgumentType>) -> List<Instruction>
 )
 
 sealed class InstructionPattern(
@@ -20,7 +20,12 @@ class TemplatePattern(
     rootClass: OperationType,
     kind: InstructionKind,
     cost: Int,
-    val lambdaInstruction: (operands : List<OperandArgumentType>, destRegister : Assignable?) -> List<Instruction>
+    /* Valid types of dest:
+     * - listOf() (empty list) - when kind == EXEC
+     * - listOf(Assignable) - when kind == VALUE
+     * - listOf(Label, Label) - when kind == JUMP
+     */
+    val lambdaInstruction: (operands : List<OperandArgumentType>, dest : List<OperandArgumentType>) -> List<Instruction>
 ) : InstructionPattern(rootClass, kind, cost) {
 
     override fun matches(parseTree: Tree): InstructionMatchResult? {


### PR DESCRIPTION
Add instruction patterns for JUMP and EXEC. Not all instructions have all three types - I don't see use cases and reasonable implementations.