### PR TITLE
Add DelayedConstantTree, add tests

### DIFF
--- a/app/src/main/kotlin/org/exeval/cfg/Tree.kt
+++ b/app/src/main/kotlin/org/exeval/cfg/Tree.kt
@@ -37,6 +37,8 @@ data class LabelConstantTree(val label: Label) : ConstantTree
 
 data class NumericalConstantTree(val value: Long) : ConstantTree
 
+data class DelayedNumericalConstantTree(val getValue: () -> Long) : ConstantTree
+
 sealed interface AssignableTree : Tree
 
 data class MemoryTree(val address: Tree) : AssignableTree

--- a/app/src/main/kotlin/org/exeval/instructions/Instruction.kt
+++ b/app/src/main/kotlin/org/exeval/instructions/Instruction.kt
@@ -31,6 +31,9 @@ fun argToString(arg: OperandArgumentType, mapping: Map<Register, PhysicalRegiste
         is NumericalConstant -> {
             arg.value.toString()
         }
+        is DelayedNumericalConstant -> {
+            arg.getValue().toString()
+        }
         is Label -> {
             arg.name
         }

--- a/app/src/main/kotlin/org/exeval/instructions/InstructionPattern.kt
+++ b/app/src/main/kotlin/org/exeval/instructions/InstructionPattern.kt
@@ -24,6 +24,7 @@ interface AssignableDest : OperandArgumentType
 interface ConstantOperandArgumentType : OperandArgumentType
 
 data class NumericalConstant(val value: Long) : ConstantOperandArgumentType
+data class DelayedNumericalConstant(val getValue: () -> Long) : ConstantOperandArgumentType
 
 class TemplatePattern(
     override val rootType: TreeKind,
@@ -76,7 +77,9 @@ class TemplatePattern(
         return when(tree) {
             is LabelConstantTree -> tree.label
             is NumericalConstantTree -> NumericalConstant(tree.value)
+            is DelayedNumericalConstantTree -> DelayedNumericalConstant(tree.getValue)
             is Call -> tree.label
+            is RegisterTree -> if (tree.register is PhysicalRegister) { tree.register } else { null }
             else -> null
         }
     }

--- a/app/src/test/kotlin/org/exeval/instructions/InstructionCovererTest.kt
+++ b/app/src/test/kotlin/org/exeval/instructions/InstructionCovererTest.kt
@@ -1,6 +1,5 @@
 package org.exeval.instructions
 
-import com.sun.source.tree.BinaryTree
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify

--- a/app/src/test/kotlin/org/exeval/instructions/TemplatePatternTest.kt
+++ b/app/src/test/kotlin/org/exeval/instructions/TemplatePatternTest.kt
@@ -1,0 +1,120 @@
+package org.exeval.instructions
+
+import org.exeval.cfg.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class TemplatePatternTest {
+
+	class TestInstruction(val arguments: List<OperandArgumentType>): Instruction {
+		override fun toAsm(mapping: Map<Register, PhysicalRegister>): String = ""
+		override fun usedRegisters(): List<Register> = listOf()
+		override fun definedRegisters(): List<Register> = listOf()
+		override fun isCopy(): Boolean = false
+	}
+
+	private fun createPattern() =
+		TemplatePattern(
+			BinaryAddTreeKind,
+			InstructionKind.EXEC,
+			1,
+			{_, inputs, _ -> listOf(TestInstruction(inputs))}
+		)
+
+	private fun createTree(left: Tree, right: Tree) =
+		BinaryOperationTree(left, right, BinaryTreeOperationType.ADD)
+
+	fun validateInstructionCreation(
+		matchResult: InstructionMatchResult,
+		inputs: List<VirtualRegister>
+	): TestInstruction {
+		val instructions = matchResult.createInstruction(null, inputs, null)
+		assertEquals(1, instructions.size, "Exactly one instruction should be returned")
+		assertTrue(
+			instructions[0] is TestInstruction,
+			"Returned instruction should be a TestInstruction"
+		)
+
+		val instr = instructions[0] as TestInstruction
+		assertEquals(
+			2,
+			instr.arguments.size,
+			"Exactly two arguments should be passed to instantiated instruction"
+		)
+		return instr
+	}
+
+	@Test
+	fun `simple match only virtual registers`() {
+		val pattern = createPattern()
+		val reg1 = VirtualRegister()
+		val reg2 = VirtualRegister()
+		val tree = createTree(RegisterTree(reg1), RegisterTree(reg2))
+
+		val matchResult = pattern.matches(tree)
+		assertNotNull(matchResult, "Match should succeed")
+
+		val instr = validateInstructionCreation(matchResult!!, listOf(reg1, reg2))
+		assertSame(reg1, instr.arguments[0])
+		assertSame(reg2, instr.arguments[1])
+	}
+
+	@Test
+	fun `simple match only physical registers`() {
+		val pattern = createPattern()
+		val tree = createTree(RegisterTree(PhysicalRegister.RAX), RegisterTree(PhysicalRegister.R13))
+
+		val matchResult = pattern.matches(tree)
+		assertNotNull(matchResult, "Match should succeed")
+
+		val instr = validateInstructionCreation(matchResult!!, emptyList<VirtualRegister>())
+		assertSame(PhysicalRegister.RAX, instr.arguments[0])
+		assertSame(PhysicalRegister.R13, instr.arguments[1])
+	}
+
+	@Test
+	fun `simple match with constant`() {
+		val pattern = createPattern()
+		val reg = VirtualRegister()
+		val tree = createTree(NumericalConstantTree(3), RegisterTree(reg))
+
+		val matchResult = pattern.matches(tree)
+		assertNotNull(matchResult, "Match should succeed")
+
+		val instr = validateInstructionCreation(matchResult!!, listOf(reg))
+		assertTrue(instr.arguments[0] is NumericalConstant)
+		assertEquals(3, (instr.arguments[0] as NumericalConstant).value)
+		assertSame(reg, instr.arguments[1])
+	}
+
+	@Test
+	fun `simple match with delayed constant`() {
+		val pattern = createPattern()
+		val reg = VirtualRegister()
+		val tree = createTree(RegisterTree(reg), DelayedNumericalConstantTree({ 4 }))
+
+		val matchResult = pattern.matches(tree)
+		assertNotNull(matchResult, "Match should succeed")
+
+		val instr = validateInstructionCreation(matchResult!!, listOf(reg))
+		assertSame(reg, instr.arguments[0])
+		assertTrue(instr.arguments[1] is DelayedNumericalConstant)
+		assertEquals(4, (instr.arguments[1] as DelayedNumericalConstant).getValue())
+	}
+
+	@Test
+	fun `simple match with label`() {
+		val pattern = createPattern()
+		val reg = VirtualRegister()
+		val label = Label("label")
+		val tree = createTree(RegisterTree(reg), LabelConstantTree(label))
+
+		val matchResult = pattern.matches(tree)
+		assertNotNull(matchResult, "Match should succeed")
+
+		val instr = validateInstructionCreation(matchResult!!, listOf(reg))
+		assertSame(reg, instr.arguments[0])
+		assertSame(label, instr.arguments[1])
+	}
+
+}

--- a/app/src/test/kotlin/org/exeval/instructions/instructionTest.kt
+++ b/app/src/test/kotlin/org/exeval/instructions/instructionTest.kt
@@ -18,4 +18,43 @@ class IntructionTest {
         val mapping: Map<Register, PhysicalRegister> = mapOf(reg to PhysicalRegister.R10, PhysicalRegister.RAX to PhysicalRegister.RAX)
         assertEquals(addInstr.toAsm(mapping), "ADD RAX, R10")
     }
+
+    @Test
+    fun `test delayed constant extraction`() {
+        val reg = VirtualRegister()
+        val delayedConstant = DelayedNumericalConstant({ 5 })
+        val subInstr = SubInstruction(reg, delayedConstant)
+        assertEquals(subInstr.isCopy(), false)
+        assertEquals(subInstr.usedRegisters(), listOf(reg))
+        assertEquals(subInstr.definedRegisters(), listOf(reg))
+        val mapping: Map<Register, PhysicalRegister> = mapOf(reg to PhysicalRegister.R8)
+        assertEquals(subInstr.toAsm(mapping), "SUB R8, 5")
+    }
+
+    @Test
+    fun `mov isn't copy`() {
+        val reg = VirtualRegister()
+        val constant = NumericalConstant(7)
+        val movInstr = MovInstruction(reg, constant)
+        assertEquals(movInstr.isCopy(), false)
+        assertEquals(movInstr.usedRegisters(), emptyList<Register>())
+        assertEquals(movInstr.definedRegisters(), listOf(reg))
+        val mapping: Map<Register, PhysicalRegister> = mapOf(reg to PhysicalRegister.R9)
+        assertEquals(movInstr.toAsm(mapping), "MOV R9, 7")
+    }
+
+    @Test
+    fun `mov is copy`() {
+        val reg1 = VirtualRegister()
+        val reg2 = VirtualRegister()
+        val movInstr = MovInstruction(reg1, reg2)
+        assertEquals(movInstr.isCopy(), true)
+        assertEquals(movInstr.usedRegisters(), listOf(reg2))
+        assertEquals(movInstr.definedRegisters(), listOf(reg1))
+        val mapping: Map<Register, PhysicalRegister> = mapOf(
+            reg1 to PhysicalRegister.RDX,
+            reg2 to PhysicalRegister.RCX
+        )
+        assertEquals(movInstr.toAsm(mapping), "MOV RDX, RCX")
+    }
 }


### PR DESCRIPTION
Added `DelayedConstantTree` and its handling in `InstructionPattern.matches` and `Instruction.toAsm`.

Added some tests to the modified classes.

Ensuring that the value cannot be changed after it's read will be done in lambda passed from `FunctionFrameManager`.